### PR TITLE
Fix for Thunderbird 68

### DIFF
--- a/src/chrome/content/preferences.js
+++ b/src/chrome/content/preferences.js
@@ -1,3 +1,16 @@
+Preferences.addAll([
+    { id: "extensions.enhancedDateFormatter.useCustomFormatsForDateColumn", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.useCustomFormatsForReceivedColumn", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.useCustomFormatsForMessagePane", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.defaultDateFormat", type: "string" },
+    { id: "extensions.enhancedDateFormatter.useCustomFormatForToday", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.todayDateFormat", type: "string" },
+    { id: "extensions.enhancedDateFormatter.useCustomFormatForYesterday", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.yesterdayDateFormat", type: "string" },
+    { id: "extensions.enhancedDateFormatter.useCustomFormatForLastWeek", type: "bool" },
+    { id: "extensions.enhancedDateFormatter.lastWeekDateFormat", type: "string" },
+]);
+
 function setDisabledOrEnabled(ids, value) {
     if(value) {
         for (let id of ids) {

--- a/src/chrome/content/preferences.xul
+++ b/src/chrome/content/preferences.xul
@@ -1,55 +1,24 @@
 <?xml version="1.0"?>
 <?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <?xml-stylesheet href="chrome://messenger/skin/preferences/preferences.css" type="text/css" ?>
+<?xml-stylesheet href="chrome://messenger/skin/messenger.css" type="text/css" ?>
 
-<prefwindow id="EnhancedDateFormatterPrefs"
+<dialog id="EnhancedDateFormatterPrefs"
+            buttons="accept"
             title="Enhanced Date Formatter Preferences"
             onload="EnhancedDateFormatter.onPrefWindowLoad()"
             xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
             >
-  
-  <prefpane id="EnhancedDateFormatterPrefs-pane">
 
+  <vbox id="EnhancedDateFormatterPrefs-pane">
+
+  <script type="application/javascript" src="chrome://global/content/preferencesBindings.js" />
   <script type="application/javascript" src="chrome://enhanceddateformatter/content/enhancedDateFormatter.js"/>
   <script type="application/javascript" src="chrome://enhanceddateformatter/content/preferences.js"/>
 
-    
-    <preferences>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatsForDateColumn"
-                  name="extensions.enhancedDateFormatter.useCustomFormatsForDateColumn"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatsForReceivedColumn"
-                  name="extensions.enhancedDateFormatter.useCustomFormatsForReceivedColumn"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatsForMessagePane"
-                  name="extensions.enhancedDateFormatter.useCustomFormatsForMessagePane"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.defaultDateFormat"
-                  name="extensions.enhancedDateFormatter.defaultDateFormat"
-                  type="string"/>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatForToday"
-                  name="extensions.enhancedDateFormatter.useCustomFormatForToday"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.todayDateFormat"
-                  name="extensions.enhancedDateFormatter.todayDateFormat"
-                  type="string"/>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatForYesterday"
-                  name="extensions.enhancedDateFormatter.useCustomFormatForYesterday"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.yesterdayDateFormat"
-                  name="extensions.enhancedDateFormatter.yesterdayDateFormat"
-                  type="string"/>
-      <preference id="extensions.enhancedDateFormatter.useCustomFormatForLastWeek"
-                  name="extensions.enhancedDateFormatter.useCustomFormatForLastWeek"
-                  type="bool"/>
-      <preference id="extensions.enhancedDateFormatter.lastWeekDateFormat"
-                  name="extensions.enhancedDateFormatter.lastWeekDateFormat"
-                  type="string"/>
-    </preferences>
-
     <hbox>
       <groupbox flex="1">
-        <caption label="Use custom date formats for" />
+        <hbox class="groupbox-title"><label class="header">Use custom date formats for</label></hbox>
         <hbox>
           <checkbox id="checkbox_useCustomFormatsForDateColumn"
                     label="Date column"
@@ -66,7 +35,7 @@
         </hbox>
 
         <description style="font-weight: bold">Note: To view your changes, you may need to restart Thunderbird.</description>
-        
+
         <hbox align="center">
           <vbox>
             <label id="label_defaultDateFormat" control="textbox_defaultDateFormat">
@@ -80,7 +49,7 @@
         </hbox>
 
         <groupbox>
-          <caption label="Messages with today's date" />
+          <hbox class="groupbox-title"><label class="header">Messages with today's date</label></hbox>
           <checkbox id="checkbox_useCustomFormatForToday"
                     label="Use a custom format for messages with today's date"
                     preference="extensions.enhancedDateFormatter.useCustomFormatForToday"
@@ -90,9 +59,9 @@
             <textbox id="textbox_todayDateFormat" preference="extensions.enhancedDateFormatter.todayDateFormat"/>
           </hbox>
         </groupbox>
-        
+
         <groupbox>
-          <caption label="Messages with yesterday's date" />
+          <hbox class="groupbox-title"><label class="header">Messages with yesterday's date</label></hbox>
           <checkbox id="checkbox_useCustomFormatForYesterday"
                     label="Use a custom format for messages with yesterday's date"
                     preference="extensions.enhancedDateFormatter.useCustomFormatForYesterday"
@@ -104,7 +73,7 @@
         </groupbox>
 
         <groupbox>
-          <caption label="Messages with a date in the last seven days" />
+          <hbox class="groupbox-title"><label class="header">Messages with a date in the last seven days</label></hbox>
           <checkbox id="checkbox_useCustomFormatForLastWeek"
                     label="Use a custom format for messages with lastWeek's date"
                     preference="extensions.enhancedDateFormatter.useCustomFormatForLastWeek"
@@ -118,232 +87,227 @@
       </groupbox>
 
       <separator class="groove" orient="vertical" />
-      
 
       <groupbox flex="1">
-        <caption label="Guide to custom format fields" />
+        <hbox class="groupbox-title"><label class="header">Guide to custom format fields</label></hbox>
 
-			   <listbox id="theList" rows="20" width="400">
-				   <listhead>
-					   <listheader label="Symbol"/>
-					   <listheader label="Description" />
-				   </listhead>
-				   <listcols>
-					   <listcol/>
-					   <listcol flex="1"/>
-				   </listcols>
-				<listitem>
-				  <listcell label="Day"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%a"/>
-				  <listcell label="abbreviated weekday name."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%A"/>
-				  <listcell label="full weekday name."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%d"/>
-				  <listcell label="day of the month [01,31]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%e"/>
-				  <listcell label="day of the month [1,31]; "/>
-				</listitem>
-				<listitem>
-				  <listcell label="%j"/>
-				  <listcell label="day of the year [001,366]."/>
-				</listitem>
+               <richlistbox id="theList" rows="20" width="400" height="500">
+                <listheader equalsize="always" style="border: 0; padding: 0; -moz-appearance: none;">
+                  <treecol label="Symbol" width="90" />
+                  <treecol label="Description" />
+                </listheader>
+                <richlistitem>
+                  <label value="Day" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%a" width="90" />
+                  <label value="abbreviated weekday name." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%A" width="90" />
+                  <label value="full weekday name." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%d" width="90" />
+                  <label value="day of the month [01,31]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%e" width="90" />
+                  <label value="day of the month [1,31]; " />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%j" width="90" />
+                  <label value="day of the year [001,366]." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Month"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%b"/>
-				  <listcell label="abbreviated month name."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%B"/>
-				  <listcell label="full month name."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%m"/>
-				  <listcell label="month [01,12]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%n"/>
-				  <listcell label="month [1,12]."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Month" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%b" width="90" />
+                  <label value="abbreviated month name." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%B" width="90" />
+                  <label value="full month name." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%m" width="90" />
+                  <label value="month [01,12]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%n" width="90" />
+                  <label value="month [1,12]." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Year"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%y"/>
-				  <listcell label="year without century [00,99]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%Y"/>
-				  <listcell label="full year [0000,9999]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%C"/>
-				  <listcell label="century number [00,99]."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Year" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%y" width="90" />
+                  <label value="year without century [00,99]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%Y" width="90" />
+                  <label value="full year [0000,9999]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%C" width="90" />
+                  <label value="century number [00,99]." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Week"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%u"/>
-				  <listcell label="weekday [1,7], with 1 representing Monday."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%V"/>
-				  <listcell label="week number of the year (Monday as the first day of the week) [01,53]. "/>
-				</listitem>
-				<listitem>
-				  <listcell label="%w"/>
-				  <listcell label="weekday [0,6], with 0 representing Sunday."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Week" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%u" width="90" />
+                  <label value="weekday [1,7], with 1 representing Monday." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%V" width="90" />
+                  <label value="week number of the year (Monday as the first day of the week) [01,53]. " />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%w" width="90" />
+                  <label value="weekday [0,6], with 0 representing Sunday." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Hour"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%H"/>
-				  <listcell label="hour (24-hour clock) [00,23]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%k"/>
-				  <listcell label="hour (24-hour clock) [0,23]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%I"/>
-				  <listcell label="hour (12-hour clock) [01,12]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%l"/>
-				  <listcell label="hour (12-hour clock) [1,12]."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Hour" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%H" width="90" />
+                  <label value="hour (24-hour clock) [00,23]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%k" width="90" />
+                  <label value="hour (24-hour clock) [0,23]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%I" width="90" />
+                  <label value="hour (12-hour clock) [01,12]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%l" width="90" />
+                  <label value="hour (12-hour clock) [1,12]." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Minute"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%M"/>
-				  <listcell label="minute [00,59]."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Minute" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%M" width="90" />
+                  <label value="minute [00,59]." />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Second"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%S"/>
-				  <listcell label="second [00,59]."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%s"/>
-				  <listcell label="number of seconds since 1970-01-01 00:00:00 +0000 (UTC)."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Second" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%S" width="90" />
+                  <label value="second [00,59]." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%s" width="90" />
+                  <label value="number of seconds since 1970-01-01 00:00:00 +0000 (UTC)." />
+                </richlistitem>
 
-        
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="AM/PM"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%p"/>
-				  <listcell label="AM or PM"/>
-				</listitem>
-				<listitem>
-				  <listcell label="%P"/>
-				  <listcell label="am or pm"/>
-				</listitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Timezone"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%Z"/>
-				  <listcell label="timezone name."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%z"/>
-				  <listcell label="+hhmm or -hhmm numeric timezone."/>
-				</listitem>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="AM/PM" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%p" width="90" />
+                  <label value="AM or PM" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%P" width="90" />
+                  <label value="am or pm" />
+                </richlistitem>
 
-				<listitem>
-				  <listcell label=""/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="Combinations"/>
-				  <listcell label=""/>
-				</listitem>
-				<listitem>
-				  <listcell label="%c"/>
-				  <listcell label="date and time in UTC."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%F"/>
-				  <listcell label="equivalent to %Y-%m-%d."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%x"/>
-				  <listcell label="date."/>
-				</listitem>
-				<listitem>
-				  <listcell label="%X"/>
-				  <listcell label="time."/>
-				</listitem>
-			   </listbox>
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Timezone" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%Z" width="90" />
+                  <label value="timezone name." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%z" width="90" />
+                  <label value="+hhmm or -hhmm numeric timezone." />
+                </richlistitem>
+
+                <richlistitem>
+                  <label value="" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="Combinations" width="90" />
+                  <label value="" />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%c" width="90" />
+                  <label value="date and time in UTC." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%F" width="90" />
+                  <label value="equivalent to %Y-%m-%d." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%x" width="90" />
+                  <label value="date." />
+                </richlistitem>
+                <richlistitem>
+                  <label value="%X" width="90" />
+                  <label value="time." />
+                </richlistitem>
+        </richlistbox>
 
       </groupbox>
       
       
     </hbox>
-  </prefpane>
-  
-</prefwindow>
+  </vbox>
+
+</dialog>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 2,
+  "name": "Enhanced Date Formatter",
+  "version": "1.0.1",
+  "author": "Jeremy Gillula",
+  "homepage_url": "https://github.com/jgillula/Enhanced-Date-Formatter-for-Thunderbird",
+  "description": "Configure the 'Date' and 'Received' columns and displayed date in the message pane using custom formats.",
+  "applications": {
+    "gecko": {
+      "id": "enhanceddateformatter@jeremy.gillula",
+      "strict_min_version": "63"
+    }
+  },
+  "legacy": {
+    "type": "xul",
+    "options": {
+      "page": "chrome://enhanceddateformatter/content/preferences.xul"
+    }
+  },
+  "icons": {
+    "32": "chrome/content/icon.png"
+  }
+}


### PR DESCRIPTION
Hi, I made a tweak and it's kind of working with Thunderbird 68. (#2)

* [Added `manifest.json`](https://developer.thunderbird.net/add-ons/tb68/changes#less-than-prefwindow-greater-than-less-than-prefpane-greater-than-less-than-preferences-greater-than-and-less-than-preference-greater-than) so that Thunderbird 68 can load the add-on
   (`install.rdf` is no longer needed, but I didn't remove that because I was lazy to fix the build script)
* [Fixed preference dialog](https://developer.thunderbird.net/add-ons/tb68/overlays#switch-to-json-manifest). `<preferences>` tag is replaced with their compat utility.

XPI Binary is [here](https://github.com/snipsnipsnip/Enhanced-Date-Formatter-for-Thunderbird/releases/download/v1.0.1-tb68-unofficial/enhanced_date_formatter-1.0.1-tb68.xpi).